### PR TITLE
Fixes #16 adds support for a payload in responses

### DIFF
--- a/api/src/main/java/edu/jhuapl/dorset/rest/WebResponse.java
+++ b/api/src/main/java/edu/jhuapl/dorset/rest/WebResponse.java
@@ -27,12 +27,9 @@ import edu.jhuapl.dorset.Response;
  */
 @XmlRootElement
 public class WebResponse {
-    private String text;
-
-    /**
-     * Empty constructor required by Jersey
-     */
-    public WebResponse() {}
+    protected final String type;
+    // see Response.Type for the supported type strings
+    protected final String text;
 
     /**
      * Create a web response
@@ -40,16 +37,28 @@ public class WebResponse {
      * @param resp  the response from the Dorset application
      */
     public WebResponse(Response resp) {
+        this.type = resp.getType().getValue();
         this.text = resp.getText();
     }
 
     /**
      * Create a web response
      *
-     * @param text  the text of the response
+     * @param type  the response type
+     * @param text  the response text
      */
-    public WebResponse(String text) {
+    public WebResponse(String type, String text) {
+        this.type = type;
         this.text = text;
+    }
+
+    /**
+     * Get the response type
+     *
+     * @return the response type
+     */
+    public String getType() {
+        return type;
     }
 
     /**
@@ -59,14 +68,5 @@ public class WebResponse {
      */
     public String getText() {
         return text;
-    }
-
-    /**
-     * Set the text of the response
-     *
-     * @param text  the text of the response
-     */
-    public void setText(String text) {
-        this.text = text;
     }
 }

--- a/api/src/main/java/edu/jhuapl/dorset/rest/WebResponseWithError.java
+++ b/api/src/main/java/edu/jhuapl/dorset/rest/WebResponseWithError.java
@@ -16,15 +16,18 @@
  */
 package edu.jhuapl.dorset.rest;
 
+import javax.xml.bind.annotation.XmlRootElement;
+
 import edu.jhuapl.dorset.Response;
 
+/**
+ * Web response with an error
+ * <p>
+ * Extends the WebResponse with the optional error information
+ */
+@XmlRootElement
 public class WebResponseWithError extends WebResponse {
-    private Error error;
-
-    /**
-     * Empty constructor required by Jersey
-     */
-    public WebResponseWithError() {}
+    protected final Error error;
 
     /**
      * Create a web response
@@ -32,6 +35,7 @@ public class WebResponseWithError extends WebResponse {
      * @param resp  the response from the Dorset application
      */
     public WebResponseWithError(Response resp) {
+        super(resp);
         error = new Error(resp.getStatus());
     }
 
@@ -41,6 +45,7 @@ public class WebResponseWithError extends WebResponse {
      * @param text  the text of the response
      */
     public WebResponseWithError(Error error) {
+        super(Response.Type.ERROR.getValue(), null);
         this.error = error;
     }
 
@@ -51,15 +56,6 @@ public class WebResponseWithError extends WebResponse {
      */
     public Error getError() {
         return error;
-    }
-
-    /**
-     * Set the error for the response
-     *
-     * @param error  the error
-     */
-    public void setError(Error error) {
-        this.error = error;
     }
 
 }

--- a/api/src/main/java/edu/jhuapl/dorset/rest/WebResponseWithPayload.java
+++ b/api/src/main/java/edu/jhuapl/dorset/rest/WebResponseWithPayload.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 The Johns Hopkins University Applied Physics Laboratory LLC
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.jhuapl.dorset.rest;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import edu.jhuapl.dorset.Response;
+
+/**
+ * Web response with payload data
+ * <p>
+ * Extends the WebResponse with the optional payload information
+ */
+@XmlRootElement
+public class WebResponseWithPayload extends WebResponse {
+    private final String payload;
+
+    /**
+     * Create a web response with a payload
+     *
+     * @param resp  the response from the Dorset application
+     */
+    public WebResponseWithPayload(Response resp) {
+        super(resp);
+        this.payload = resp.getPayload();
+    }
+
+    /**
+     * Get the payload string
+     *
+     * @return the payload
+     */
+    public String getPayload() {
+        return payload;
+    }
+}

--- a/api/src/main/java/edu/jhuapl/dorset/rest/WebService.java
+++ b/api/src/main/java/edu/jhuapl/dorset/rest/WebService.java
@@ -56,7 +56,11 @@ public class WebService {
         Request request = new Request(req.getText());
         Response response = app.process(request);
         if (response.isSuccess()) {
-            webResp = new WebResponse(response);
+            if (response.hasPayload()) {
+                webResp = new WebResponseWithPayload(response);    
+            } else {
+                webResp = new WebResponse(response);
+            }
         } else {
             webResp = new WebResponseWithError(response);
         }

--- a/api/src/test/java/edu/jhuapl/dorset/rest/WebServiceTest.java
+++ b/api/src/test/java/edu/jhuapl/dorset/rest/WebServiceTest.java
@@ -76,7 +76,7 @@ public class WebServiceTest extends JerseyTest {
         javax.ws.rs.core.Response response = target("/request").request(MediaType.APPLICATION_JSON_TYPE).post(body);
 
         assertEquals(200, response.getStatus());
-        String expected = "{\"text\":\"this is a test\"}";
+        String expected = "{\"type\":\"text\",\"text\":\"this is a test\"}";
         assertEquals(expected, response.readEntity(String.class));
     }
 
@@ -90,7 +90,7 @@ public class WebServiceTest extends JerseyTest {
         javax.ws.rs.core.Response response = target("/request").request(MediaType.APPLICATION_JSON_TYPE).post(body);
 
         assertEquals(200, response.getStatus());
-        String expected = "{\"text\":null,\"error\":{\"code\":201,\"message\":\"Huh?\"}}";
+        String expected = "{\"type\":\"error\",\"text\":null,\"error\":{\"code\":201,\"message\":\"Huh?\"}}";
         assertEquals(expected, response.readEntity(String.class));
     }
 

--- a/api/src/test/java/edu/jhuapl/dorset/rest/WebServiceTest.java
+++ b/api/src/test/java/edu/jhuapl/dorset/rest/WebServiceTest.java
@@ -95,6 +95,20 @@ public class WebServiceTest extends JerseyTest {
     }
 
     @Test
+    public void testRequestWithPayload() {
+        Response resp = new Response(Response.Type.EMBEDDED_IMAGE, "Here is your image", "base64_image");
+        when(app.process(any(Request.class))).thenReturn(resp);
+
+        WebRequest wr = new WebRequest("show me a flamingo");
+        Entity<WebRequest> body = Entity.entity(wr, MediaType.APPLICATION_JSON_TYPE);
+        javax.ws.rs.core.Response response = target("/request").request(MediaType.APPLICATION_JSON_TYPE).post(body);
+
+        assertEquals(200, response.getStatus());
+        String expected = "{\"type\":\"embedded_image\",\"text\":\"Here is your image\",\"payload\":\"base64_image\"}";
+        assertEquals(expected, response.readEntity(String.class));
+    }
+
+    @Test
     public void testPing() {
         javax.ws.rs.core.Response response = target("/ping").request(MediaType.APPLICATION_JSON_TYPE).get();
 

--- a/core/src/main/java/edu/jhuapl/dorset/Response.java
+++ b/core/src/main/java/edu/jhuapl/dorset/Response.java
@@ -25,6 +25,7 @@ import edu.jhuapl.dorset.agent.AgentResponse;
  * The text field can be null if an error occurred.
  */
 public class Response {
+    private final Type type;
     private final String text;
     private final ResponseStatus status;
 
@@ -34,6 +35,7 @@ public class Response {
      * @param text  the text of the response
      */
     public Response(String text) {
+        this.type = Type.TEXT;
         this.text = text;
         this.status = ResponseStatus.createSuccess();
     }
@@ -44,6 +46,7 @@ public class Response {
      * @param response  response from an agent
      */
     public Response(AgentResponse response) {
+        this.type = response.getType();
         this.text = response.getText();
         this.status = response.getStatus();
     }
@@ -55,6 +58,11 @@ public class Response {
      * @param status  the response status
      */
     public Response(String text, ResponseStatus status) {
+        if (status.isSuccess()) {
+            this.type = Type.TEXT;
+        } else {
+            this.type = Type.ERROR;
+        }
         this.text = text;
         this.status = status;
     }
@@ -62,11 +70,21 @@ public class Response {
     /**
      * Create a response
      *
-     * @param status  the response status (usually an error)
+     * @param status  the response status (an error)
      */
     public Response(ResponseStatus status) {
+        this.type = Type.ERROR;
         this.text = null;
         this.status = status;
+    }
+
+    /**
+     * Get the response type
+     *
+     * @return the response type
+     */
+    public Type getType() {
+        return type;
     }
 
     /**
@@ -94,5 +112,52 @@ public class Response {
      */
     public boolean isSuccess() {
         return status.isSuccess();
+    }
+
+    /**
+     * Is this a simple text response?
+     *
+     * @return true if text response
+     */
+    public boolean isTextResponse() {
+        return type == Type.TEXT;
+    }
+
+    /**
+     * Enumeration for response types
+     */
+    public enum Type {
+        ERROR("error"),
+        TEXT("text"),
+        EMBEDDED_IMAGE("embedded_image");
+
+        private final String type;
+        private Type(String type) {
+            this.type = type;
+        }
+
+        /**
+         * Get the value of the type
+         *
+         * @return the value
+         */
+        public String getValue() {
+            return type;
+        }
+
+        /**
+         * Get a Type enum member from a string
+         *
+         * @param value  the type as a string
+         * @return a Type enum member or null if no match
+         */
+        public static Type fromValue(String value) {
+            for (Type type : Type.values()) {
+                if (type.getValue().equals(value)) {
+                    return type;
+                }
+            }
+            return null;
+        }
     }
 }

--- a/core/src/main/java/edu/jhuapl/dorset/Response.java
+++ b/core/src/main/java/edu/jhuapl/dorset/Response.java
@@ -22,11 +22,13 @@ import edu.jhuapl.dorset.agent.AgentResponse;
  * Dorset Response
  * <p>
  * Represents the response to a request to the application.
+ * The type field determines what fields are used.
  * The text field can be null if an error occurred.
  */
 public class Response {
     private final Type type;
     private final String text;
+    private final String payload;
     private final ResponseStatus status;
 
     /**
@@ -37,6 +39,21 @@ public class Response {
     public Response(String text) {
         this.type = Type.TEXT;
         this.text = text;
+        this.payload = null;
+        this.status = ResponseStatus.createSuccess();
+    }
+
+    /**
+     * Create a response with a payload
+     *
+     * @param type  the type of the response
+     * @param text  the text of the response
+     * @param payload  the payload of the response
+     */
+    public Response(Type type, String text, String payload) {
+        this.type = type;
+        this.text = text;
+        this.payload = payload;
         this.status = ResponseStatus.createSuccess();
     }
 
@@ -48,6 +65,7 @@ public class Response {
     public Response(AgentResponse response) {
         this.type = response.getType();
         this.text = response.getText();
+        this.payload = response.getPayload();
         this.status = response.getStatus();
     }
 
@@ -64,6 +82,7 @@ public class Response {
             this.type = Type.ERROR;
         }
         this.text = text;
+        this.payload = null;
         this.status = status;
     }
 
@@ -75,6 +94,7 @@ public class Response {
     public Response(ResponseStatus status) {
         this.type = Type.ERROR;
         this.text = null;
+        this.payload = null;
         this.status = status;
     }
 
@@ -94,6 +114,17 @@ public class Response {
      */
     public String getText() {
         return text;
+    }
+
+    /**
+     * Get the payload of the response
+     * <p>
+     * The payload data varies according to the response type
+     *
+     * @return payload string or null if no payload
+     */
+    public String getPayload() {
+        return payload;
     }
 
     /**
@@ -121,6 +152,15 @@ public class Response {
      */
     public boolean isTextResponse() {
         return type == Type.TEXT;
+    }
+
+    /**
+     * Does this response have a payload?
+     *
+     * @return true if there is a payload
+     */
+    public boolean hasPayload() {
+        return Type.usesPayload(type);
     }
 
     /**
@@ -158,6 +198,21 @@ public class Response {
                 }
             }
             return null;
+        }
+
+        /**
+         * Does this response type use the payload field?
+         *
+         * @param type the response type
+         * @return true if it uses the payload field
+         */
+        public static boolean usesPayload(Type type) {
+            switch (type) {
+                case EMBEDDED_IMAGE:
+                    return true;
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/core/src/main/java/edu/jhuapl/dorset/agent/AgentResponse.java
+++ b/core/src/main/java/edu/jhuapl/dorset/agent/AgentResponse.java
@@ -43,12 +43,14 @@ public class AgentResponse {
     }
 
     /**
-     * Create an agent response
+     * Create an agent response with payload
      *
+     * @param type  the response type
      * @param text  the text of the response
+     * @param payload  the payload of the response
      */
-    public AgentResponse(String text, String payload) {
-        this.type = Response.Type.TEXT;
+    public AgentResponse(Response.Type type, String text, String payload) {
+        this.type = type;
         this.text = text;
         this.payload = payload;
         this.status = ResponseStatus.createSuccess();

--- a/core/src/main/java/edu/jhuapl/dorset/agent/AgentResponse.java
+++ b/core/src/main/java/edu/jhuapl/dorset/agent/AgentResponse.java
@@ -27,6 +27,7 @@ import edu.jhuapl.dorset.ResponseStatus;
 public class AgentResponse {
     private final Response.Type type;
     private final String text;
+    private final String payload;
     private final ResponseStatus status;
 
     /**
@@ -37,6 +38,19 @@ public class AgentResponse {
     public AgentResponse(String text) {
         this.type = Response.Type.TEXT;
         this.text = text;
+        this.payload = null;
+        this.status = ResponseStatus.createSuccess();
+    }
+
+    /**
+     * Create an agent response
+     *
+     * @param text  the text of the response
+     */
+    public AgentResponse(String text, String payload) {
+        this.type = Response.Type.TEXT;
+        this.text = text;
+        this.payload = payload;
         this.status = ResponseStatus.createSuccess();
     }
 
@@ -48,6 +62,7 @@ public class AgentResponse {
     public AgentResponse(ResponseStatus.Code code) {
         this.type = Response.Type.ERROR;
         this.text = null;
+        this.payload = null;
         this.status = new ResponseStatus(code);
     }
 
@@ -59,6 +74,7 @@ public class AgentResponse {
     public AgentResponse(ResponseStatus status) {
         this.type = Response.Type.ERROR;
         this.text = null;
+        this.payload = null;
         this.status = status;
     }
 
@@ -78,6 +94,17 @@ public class AgentResponse {
      */
     public String getText() {
         return text;
+    }
+
+    /**
+     * Get the payload of the response
+     * <p>
+     * The payload data varies according to the response type
+     *
+     * @return payload string or null if no payload
+     */
+    public String getPayload() {
+        return payload;
     }
 
     /**
@@ -104,7 +131,10 @@ public class AgentResponse {
      * @return true if valid
      */
     public boolean isValid() {
-        if (status == null) {
+        if (type == null || status == null) { 
+            return false;
+        }
+        if (Response.Type.usesPayload(type) && payload == null) {
             return false;
         }
         return !(isSuccess() && text == null);

--- a/core/src/main/java/edu/jhuapl/dorset/agent/AgentResponse.java
+++ b/core/src/main/java/edu/jhuapl/dorset/agent/AgentResponse.java
@@ -16,6 +16,7 @@
  */
 package edu.jhuapl.dorset.agent;
 
+import edu.jhuapl.dorset.Response;
 import edu.jhuapl.dorset.ResponseStatus;
 
 /**
@@ -24,6 +25,7 @@ import edu.jhuapl.dorset.ResponseStatus;
  * This class is part of the public API for remote agent web services.
  */
 public class AgentResponse {
+    private final Response.Type type;
     private final String text;
     private final ResponseStatus status;
 
@@ -33,6 +35,7 @@ public class AgentResponse {
      * @param text  the text of the response
      */
     public AgentResponse(String text) {
+        this.type = Response.Type.TEXT;
         this.text = text;
         this.status = ResponseStatus.createSuccess();
     }
@@ -43,6 +46,7 @@ public class AgentResponse {
      * @param code  the status code
      */
     public AgentResponse(ResponseStatus.Code code) {
+        this.type = Response.Type.ERROR;
         this.text = null;
         this.status = new ResponseStatus(code);
     }
@@ -53,8 +57,18 @@ public class AgentResponse {
      * @param status  the status of the response
      */
     public AgentResponse(ResponseStatus status) {
+        this.type = Response.Type.ERROR;
         this.text = null;
         this.status = status;
+    }
+
+    /**
+     * Get the response type
+     *
+     * @return the response type
+     */
+    public Response.Type getType() {
+        return type;
     }
 
     /**

--- a/core/src/main/java/edu/jhuapl/dorset/agent/RemoteAgent.java
+++ b/core/src/main/java/edu/jhuapl/dorset/agent/RemoteAgent.java
@@ -23,6 +23,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 
+import edu.jhuapl.dorset.Response;
 import edu.jhuapl.dorset.ResponseStatus;
 import edu.jhuapl.dorset.http.HttpClient;
 
@@ -55,6 +56,7 @@ public class RemoteAgent extends AbstractAgent {
         setUrls();
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(ResponseStatus.Code.class, new ResponseCodeDeserializer());
+        gsonBuilder.registerTypeAdapter(Response.Type.class, new ResponseTypeDeserializer());
         gson = gsonBuilder.create();
     }
 

--- a/core/src/main/java/edu/jhuapl/dorset/agent/ResponseTypeDeserializer.java
+++ b/core/src/main/java/edu/jhuapl/dorset/agent/ResponseTypeDeserializer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 The Johns Hopkins University Applied Physics Laboratory LLC
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.jhuapl.dorset.agent;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import edu.jhuapl.dorset.Response;
+
+/**
+ * Gson deserializer for the Response.Type enumeration
+ */
+public class ResponseTypeDeserializer implements JsonDeserializer<Response.Type> {
+    @Override
+    public Response.Type deserialize(JsonElement element, Type type, JsonDeserializationContext ctx)
+                    throws JsonParseException {
+        return Response.Type.fromValue(element.getAsString());
+    }
+}

--- a/core/src/test/java/edu/jhuapl/dorset/ResponseTest.java
+++ b/core/src/test/java/edu/jhuapl/dorset/ResponseTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 The Johns Hopkins University Applied Physics Laboratory LLC
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.jhuapl.dorset;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import edu.jhuapl.dorset.Response.Type;
+
+public class ResponseTest {
+
+    @Test
+    public void testFromValue() {
+        assertEquals(Type.TEXT, Type.fromValue("text"));
+        assertEquals(Type.ERROR, Type.fromValue("error"));
+        assertNull(Type.fromValue("nonsuch"));
+    }
+
+}

--- a/core/src/test/java/edu/jhuapl/dorset/agent/RemoteAgentTest.java
+++ b/core/src/test/java/edu/jhuapl/dorset/agent/RemoteAgentTest.java
@@ -42,7 +42,7 @@ public class RemoteAgentTest {
     public void testProcess() {
         HttpClient client = mock(HttpClient.class);
         when(client.post(eq("http://example.org/request"), any(String.class),
-                        eq(HttpClient.APPLICATION_JSON))).thenReturn("{\"text\":\"2\", \"status\":{\"code\":0, \"message\":\"Success\"}}");
+                        eq(HttpClient.APPLICATION_JSON))).thenReturn("{\"type\":\"text\",\"text\":\"2\", \"status\":{\"code\":0, \"message\":\"Success\"}}");
         RemoteAgent agent = new RemoteAgent("http://example.org/", client);
         AgentRequest request = new AgentRequest("what is 1 + 1?");
 


### PR DESCRIPTION
The only payload type right now is embedded image (base64 encoded image), but I can imagine adding others like json or mp3 files.
