### PR TITLE
catching exceptions in the expression parsing of calculator

### DIFF
--- a/agents/general/src/main/java/edu/jhuapl/dorset/agents/CalculatorAgent.java
+++ b/agents/general/src/main/java/edu/jhuapl/dorset/agents/CalculatorAgent.java
@@ -19,6 +19,7 @@ package edu.jhuapl.dorset.agents;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.jhuapl.dorset.ResponseStatus;
 import edu.jhuapl.dorset.agents.AbstractAgent;
 import edu.jhuapl.dorset.agents.AgentRequest;
 import edu.jhuapl.dorset.agents.AgentResponse;
@@ -42,8 +43,21 @@ public class CalculatorAgent extends AbstractAgent {
     @Override
     public AgentResponse process(AgentRequest request) {
         logger.debug("Handling the request: " + request.getText());
-        Expression exp = new ExpressionBuilder(request.getText()).build();
-        double result = exp.evaluate();
+        Expression exp = null;
+        try {
+            exp = new ExpressionBuilder(request.getText()).build();
+        } catch (IllegalArgumentException e) {
+            logger.debug("CalculatorAgent could not parse " + request.getText());
+            return new AgentResponse(ResponseStatus.Code.AGENT_DID_NOT_UNDERSTAND_REQUEST);
+        }
+
+        double result = 0;
+        try {
+            result = exp.evaluate();
+        } catch (IllegalArgumentException e) {
+            logger.debug("CalculatorAgent could not parse " + request.getText());
+            return new AgentResponse(ResponseStatus.Code.AGENT_DID_NOT_UNDERSTAND_REQUEST);
+        }
 
         // handle integers differently from floating point 
         String answer;

--- a/agents/general/src/test/java/edu/jhuapl/dorset/agents/CalculatorAgentTest.java
+++ b/agents/general/src/test/java/edu/jhuapl/dorset/agents/CalculatorAgentTest.java
@@ -35,4 +35,15 @@ public class CalculatorAgentTest {
         assertEquals("145", response.getText());
     }
 
+    @Test
+    public void testBadExpressions() {
+        Agent agent = new CalculatorAgent();
+
+        AgentResponse response = agent.process(new AgentRequest("2 + "));
+        assertFalse(response.isSuccess());
+
+        response = agent.process(new AgentRequest("two plus two"));
+        assertFalse(response.isSuccess());
+    }
+
 }


### PR DESCRIPTION
This handles non-mathematical expressions and missing arguments. Eventually, we could add something that converts text like "two plus two" to "2 + 2".
