### PR TITLE
CommandLineClient now takes an Agent (vs. AbstractAgent).

### DIFF
--- a/components/tools/src/main/java/edu/jhuapl/dorset/components/tools/CommandLineClient.java
+++ b/components/tools/src/main/java/edu/jhuapl/dorset/components/tools/CommandLineClient.java
@@ -21,7 +21,7 @@ import java.util.Scanner;
 import edu.jhuapl.dorset.Application;
 import edu.jhuapl.dorset.Request;
 import edu.jhuapl.dorset.Response;
-import edu.jhuapl.dorset.agents.AbstractAgent;
+import edu.jhuapl.dorset.agents.Agent;
 import edu.jhuapl.dorset.routing.Router;
 import edu.jhuapl.dorset.routing.SingleAgentRouter;
 
@@ -51,7 +51,7 @@ public class CommandLineClient {
      * 
      * @param agent the agent to handle requests
      */
-    public CommandLineClient(AbstractAgent agent) {
+    public CommandLineClient(Agent agent) {
         this(new SingleAgentRouter(agent));
     }
 

--- a/components/tools/src/test/java/edu/jhuapl/dorset/components/tools/CommandLineClientTest.java
+++ b/components/tools/src/test/java/edu/jhuapl/dorset/components/tools/CommandLineClientTest.java
@@ -70,10 +70,10 @@ public class CommandLineClientTest {
 
     /**
      * Test method for
-     * {@link edu.jhuapl.dorset.components.tools.CommandLineClient#CommandLineClient(edu.jhuapl.dorset.agents.AbstractAgent)}.
+     * {@link edu.jhuapl.dorset.components.tools.CommandLineClient#CommandLineClient(edu.jhuapl.dorset.agents.Agent)}.
      */
     @Test
-    public void testCommandLineClientAbstractAgent() {
+    public void testCommandLineClientAgent() {
         CommandLineClient c = new CommandLineClient(mockAgent);
         testGo(c);
     }


### PR DESCRIPTION
This fixes #55 by changing the CommandLineClient constructor to use the Agent interface.
